### PR TITLE
replace arrarylist to synchronized arraylist

### DIFF
--- a/src/main/java/ru/ivi/opensource/flinkclickhousesink/applied/ClickhouseSinkBuffer.java
+++ b/src/main/java/ru/ivi/opensource/flinkclickhousesink/applied/ClickhouseSinkBuffer.java
@@ -28,7 +28,7 @@ public class ClickhouseSinkBuffer implements AutoCloseable {
             String table
     ) {
         writer = chWriter;
-        localValues = new ArrayList<>();
+        localValues = Collections.synchronizedList(new ArrayList<>());
         timeoutMillis = timeout;
         maxFlushBufferSize = maxBuffer;
         targetTable = table;


### PR DESCRIPTION
At present, a non synchronized list has issues:

1. lose records that inserted after `deepCopy` but before `localValues.clear`
2. In a rare case, `deepCopy` may generate a list of null. And it can be reproduced in any massive and consistent volume of data digestion process. ( It actually costed me a lot of time to finally realize the problem and fix it

I think it's a pretty intuitive fix, so I just jump out and propose.