### PR TITLE
fix bug when new threads are not created in callbackService even under the load

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ _by timeout_ and _by buffer size_.
 |flink    |flink-clickhouse-sink | 
 |:-------:|:--------------------:| 
 |1.3.*    |1.0.0                 |
-|1.9.0    |1.3.0                 |
+|1.9.*    |1.3.1                 |
 
 
 ### Install
@@ -29,7 +29,7 @@ _by timeout_ and _by buffer size_.
 <dependency>
   <groupId>ru.ivi.opensource</groupId>
   <artifactId>flink-clickhouse-sink</artifactId>
-  <version>1.3.0</version>
+  <version>1.3.1</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>ru.ivi.opensource</groupId>
     <artifactId>flink-clickhouse-sink</artifactId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>1.3.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Flink ClickHouse sink</name>

--- a/src/main/java/ru/ivi/opensource/flinkclickhousesink/applied/ClickHouseWriter.java
+++ b/src/main/java/ru/ivi/opensource/flinkclickhousesink/applied/ClickHouseWriter.java
@@ -72,7 +72,7 @@ public class ClickHouseWriter implements AutoCloseable {
                 Integer.MAX_VALUE,
                 60L,
                 TimeUnit.SECONDS,
-                new LinkedBlockingQueue<>(),
+                new SynchronousQueue<>(),
                 callbackServiceFactory);
 
 

--- a/src/main/java/ru/ivi/opensource/flinkclickhousesink/applied/ClickHouseWriter.java
+++ b/src/main/java/ru/ivi/opensource/flinkclickhousesink/applied/ClickHouseWriter.java
@@ -64,17 +64,7 @@ public class ClickHouseWriter implements AutoCloseable {
         service = Executors.newFixedThreadPool(sinkParams.getNumWriters(), threadFactory);
 
         ThreadFactory callbackServiceFactory = ThreadUtil.threadFactory("clickhouse-writer-callback-executor");
-
-        int cores = Runtime.getRuntime().availableProcessors();
-        int coreThreadsNum = Math.max(cores / 4, 2);
-        callbackService = new ThreadPoolExecutor(
-                coreThreadsNum,
-                Integer.MAX_VALUE,
-                60L,
-                TimeUnit.SECONDS,
-                new SynchronousQueue<>(),
-                callbackServiceFactory);
-
+        callbackService = Executors.newCachedThreadPool(callbackServiceFactory);
 
         int numWriters = sinkParams.getNumWriters();
         tasks = Lists.newArrayListWithCapacity(numWriters);


### PR DESCRIPTION
It seems that when we create `ThreadPoolExecutor` for processing async callbacks, we want our executor to create new thread when it needs to:
```java
        callbackService = new ThreadPoolExecutor(
                coreThreadsNum,
                Integer.MAX_VALUE,
                60L,
                TimeUnit.SECONDS,
                new LinkedBlockingQueue<>(),
                callbackServiceFactory);
```

But [documentation](https://docs.oracle.com/javase/7/docs/api/java/util/concurrent/ThreadPoolExecutor.html) clearly says:
> If there are more than corePoolSize but less than maximumPoolSize threads running, a new thread will be created only if the queue is full.

Since `LinkedBlockingQueue` is unbounded (bounded by `Integer.MAX_VALUE`), new thread will never (almost) be created.

My suggestion is to use `SynchronousQueue`  like it's implemented in [Executors.newCachedThreadPool()](http://hg.openjdk.java.net/jdk8/jdk8/jdk/file/687fd7c7986d/src/share/classes/java/util/concurrent/Executors.java#l215)
