### PR TITLE
Added code to nullify singManager instance after teardown. (#23)

### DIFF
--- a/src/main/java/ru/ivi/opensource/flinkclickhousesink/ClickHouseSink.java
+++ b/src/main/java/ru/ivi/opensource/flinkclickhousesink/ClickHouseSink.java
@@ -70,6 +70,7 @@ public class ClickHouseSink extends RichSinkFunction<String> {
                 synchronized (DUMMY_LOCK) {
                     if (!sinkManager.isClosed()) {
                         sinkManager.close();
+						sinkManager = null;
                     }
                 }
             }


### PR DESCRIPTION
* Nullified sinkManager instance to make restart procedure normally re-initializes sink manager again.