### PR TITLE
perf: Prevent host configuration not using space separation.

### DIFF
--- a/src/main/java/ru/ivi/opensource/flinkclickhousesink/util/ConfigUtil.java
+++ b/src/main/java/ru/ivi/opensource/flinkclickhousesink/util/ConfigUtil.java
@@ -7,7 +7,7 @@ import java.util.*;
 
 public final class ConfigUtil {
 
-    public static final String HOST_DELIMITER = ", ";
+    public static final String HOST_DELIMITER = ",";
 
     private ConfigUtil() {
 


### PR DESCRIPTION
Very easy to forget to use ```, ```(Commas and Spaces)  when config clickhouse address. 