### PR TITLE
Up lib versions and added mvn packaging step to get all of deps in

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,12 +27,12 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- Primary components -->
         <java.version>1.8</java.version>
-        <scala.version>2.11</scala.version>
-        <flink.version>1.9.0</flink.version>
+        <scala.version>2.12</scala.version>
+        <flink.version>1.20.0</flink.version>
 
         <!-- Secondary components -->
         <async.client.version>2.10.4</async.client.version>
-        <logback.version>1.2.3</logback.version>
+        <logback.version>1.2.13</logback.version>
         <guava.version>23.0</guava.version>
         <typesafe.config.version>1.3.3</typesafe.config.version>
         <ch.driver.version>0.1.40</ch.driver.version>
@@ -129,7 +129,7 @@
 
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-streaming-java_${scala.version}</artifactId>
+            <artifactId>flink-streaming-java</artifactId>
             <version>${flink.version}</version>
         </dependency>
 
@@ -201,6 +201,19 @@
                     <source>${java.version}</source>
                     <target>${java.version}</target>
                 </configuration>
+            </plugin>
+            <plugin>
+              <artifactId>maven-assembly-plugin</artifactId>
+              <configuration>
+                <archive>
+                  <manifest>
+                    <mainClass>fully.qualified.MainClass</mainClass>
+                  </manifest>
+                </archive>
+                <descriptorRefs>
+                  <descriptorRef>jar-with-dependencies</descriptorRef>
+                </descriptorRefs>
+              </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Summary:

This pull request addresses two key updates:

1. Library Dependency Upgrade: Updated the library dependencies in the ClickHouse sink module to ensure compatibility with Apache Flink 1.20

2. Maven Configuration Enhancement: Added a Maven step to package all dependencies into the JAR file.